### PR TITLE
Add support for flask > 2.2

### DIFF
--- a/flask_log_request_id/request_id.py
+++ b/flask_log_request_id/request_id.py
@@ -15,13 +15,9 @@ def flask_ctx_get_request_id():
     Get request id from flask's G object
     :return: The id or None if not found.
     """
-    from flask import _app_ctx_stack as stack  # We do not support < Flask 0.9
-
-    if stack.top is None:
-        raise ExecutedOutsideContext()
-
-    g_object_attr = stack.top.app.config['LOG_REQUEST_ID_G_OBJECT_ATTRIBUTE']
-    return g.get(g_object_attr, None)
+    if flask.has_app_context():
+        g_object_attr = g.log_request_id_g_object_attribute
+        return g.get(g_object_attr, None)
 
 
 current_request_id = MultiContextRequestIdFetcher()
@@ -73,6 +69,7 @@ class RequestID(object):
 
             To be used as a consumer of Flask.before_request event.
             """
+            g.log_request_id_g_object_attribute = app.config['LOG_REQUEST_ID_G_OBJECT_ATTRIBUTE']
             g_object_attr = current_app.config['LOG_REQUEST_ID_G_OBJECT_ATTRIBUTE']
 
             setattr(g, g_object_attr, self._request_id_parser())


### PR DESCRIPTION
According to the [Flask documentation](https://flask.palletsprojects.com/en/3.0.x/changes/#version-2-2-0), `_app_ctx_stack.top` and `_request_ctx_stack.top` are deprecated since `2.2`.

This PR fixes below exception which occurs Flask version > `2.2`.

```
    from flask import _app_ctx_stack as stack  # We do not support < Flask 0.9
ImportError: cannot import name '_app_ctx_stack' from 'flask' (/Users/talhakum/***/.venv/lib/python3.10/site-packages/flask/__init__.py)
```